### PR TITLE
Updated Liercourt names

### DIFF
--- a/data/112/597/649/7/1125976497.geojson
+++ b/data/112/597/649/7/1125976497.geojson
@@ -19,8 +19,11 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
-    "name:unk_x_variant":[
+    "name:eng_x_preferred":[
         "Liercourt"
+    ],
+    "name:fra_x_preferred":[
+        "Li\u00e9court"
     ],
     "qs_pg:aaroncc":"FR",
     "qs_pg:gn_country":"FR",
@@ -84,8 +87,8 @@
         }
     ],
     "wof:id":1125976497,
-    "wof:lastmodified":1539917360,
-    "wof:name":"Li\u00e9court",
+    "wof:lastmodified":1563230923,
+    "wof:name":"Liercourt",
     "wof:parent_id":404383323,
     "wof:placetype":"locality",
     "wof:population":327,

--- a/data/112/597/649/7/1125976497.geojson
+++ b/data/112/597/649/7/1125976497.geojson
@@ -25,6 +25,18 @@
     "name:fra_x_preferred":[
         "Li\u00e9court"
     ],
+    "name:fra_x_variant":[
+        "Liercourt"
+    ],
+    "name:pcd_x_preferred":[
+        "Li\u00e8rcourt"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041b\u044c\u0454\u0440\u043a\u0443\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u5229\u8036\u5c14\u5e93\u5c14"
+    ],
     "qs_pg:aaroncc":"FR",
     "qs_pg:gn_country":"FR",
     "qs_pg:gn_fcode":"PPL",
@@ -87,7 +99,7 @@
         }
     ],
     "wof:id":1125976497,
-    "wof:lastmodified":1563230923,
+    "wof:lastmodified":1564002601,
     "wof:name":"Liercourt",
     "wof:parent_id":404383323,
     "wof:placetype":"locality",

--- a/data/404/383/323/404383323.geojson
+++ b/data/404/383/323/404383323.geojson
@@ -25,7 +25,13 @@
     "lbl:longitude":1.896727,
     "mz:hierarchy_label":0,
     "mz:is_current":1,
+    "name:eng_x_preferred":[
+        "Liercourt"
+    ],
     "name:fra_x_preferred":[
+        "Li\u00e9court"
+    ],
+    "name:fra_x_variant":[
         "Liercourt"
     ],
     "name:pcd_x_preferred":[
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":404383323,
-    "wof:lastmodified":1539917360,
+    "wof:lastmodified":1563230930,
     "wof:name":"Liercourt",
     "wof:parent_id":102068561,
     "wof:placetype":"localadmin",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1664

- Updates `wof:name` and `name:*` properties in the locality and localadmin records for Liercourt, France.

Does not require PIP work, can merge once approved.