### PR TITLE
Fixed Vosges names

### DIFF
--- a/data/856/832/23/85683223.geojson
+++ b/data/856/832/23/85683223.geojson
@@ -17,7 +17,7 @@
         "department"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Massif des Vosges"
+        "d\u00e9partement des Vosges"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -143,11 +143,10 @@
         "Vosges"
     ],
     "name:fra_x_preferred":[
-        "Massif des Vosges"
+        "Vosges"
     ],
     "name:fra_x_variant":[
-        "D\u00e9partement des Vosges",
-        "Vosges"
+        "D\u00e9partement des Vosges"
     ],
     "name:frp_x_preferred":[
         "Vosg\u00b7es"
@@ -537,7 +536,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1563276513,
+    "wof:lastmodified":1564595891,
     "wof:name":"Vosges",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/832/23/85683223.geojson
+++ b/data/856/832/23/85683223.geojson
@@ -182,9 +182,6 @@
         "Vogezi"
     ],
     "name:hun_x_preferred":[
-        "Vog\u00e9zek"
-    ],
-    "name:hun_x_variant":[
         "Vosges"
     ],
     "name:hye_x_preferred":[
@@ -536,7 +533,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1564595891,
+    "wof:lastmodified":1564614259,
     "wof:name":"Vosges",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1687

Swaps around French translations for Vosges, France to remove the bunk name.

No PIP required, can merge once approved.