### PR TITLE
Fix locality names in FR

### DIFF
--- a/data/112/595/908/3/1125959083.geojson
+++ b/data/112/595/908/3/1125959083.geojson
@@ -70,6 +70,9 @@
     "name:eng_x_preferred":[
         "Pougny"
     ],
+    "name:eng_x_variant":[
+        "Mougny"
+    ],
     "name:epo_x_preferred":[
         "Pougny"
     ],
@@ -367,8 +370,8 @@
         }
     ],
     "wof:id":1125959083,
-    "wof:lastmodified":1563307326,
-    "wof:name":"Mougny",
+    "wof:lastmodified":1568059258,
+    "wof:name":"Pougny",
     "wof:parent_id":404423245,
     "wof:placetype":"locality",
     "wof:population":727,

--- a/data/112/597/649/7/1125976497.geojson
+++ b/data/112/597/649/7/1125976497.geojson
@@ -38,10 +38,11 @@
         "Liercourt"
     ],
     "name:fra_x_preferred":[
-        "Li\u00e9court"
+        "Li\u00e9rcourt"
     ],
     "name:fra_x_variant":[
-        "Liercourt"
+        "Liercourt",
+        "Li\u00e9court"
     ],
     "name:hun_x_preferred":[
         "Liercourt"
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1125976497,
-    "wof:lastmodified":1564142933,
+    "wof:lastmodified":1568059254,
     "wof:name":"Liercourt",
     "wof:parent_id":404383323,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1700

- Updates two locality records to fix French and English name properties

No PIP required, can merge once approved.