### PR TITLE
Update bunk names

### DIFF
--- a/data/144/483/277/9/1444832779.geojson
+++ b/data/144/483/277/9/1444832779.geojson
@@ -21,26 +21,23 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":14.0,
     "mz:tier_metro":30,
-    "name:Eng_x_preferred":[
-        "Coeur de ville"
-    ],
-    "name:Fre_x_preferred":[
-        "C\u0153ur de ville"
-    ],
     "name:eng_x_preferred":[
         "Coeur de ville"
+    ],
+    "name:fra_x_preferred":[
+        "C\u0153ur de ville"
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
     "wof:belongsto":[
-        85683157,
         102191581,
         85633147,
         1159322425,
         404227997,
         404227465,
         101749781,
-        102071965
+        102071965,
+        85683157
     ],
     "wof:breaches":[],
     "wof:country":"FR",
@@ -59,7 +56,7 @@
         }
     ],
     "wof:id":1444832779,
-    "wof:lastmodified":1566338479,
+    "wof:lastmodified":1568226904,
     "wof:name":"Coeur de ville",
     "wof:parent_id":101749781,
     "wof:placetype":"neighbourhood",

--- a/data/144/483/517/3/1444835173.geojson
+++ b/data/144/483/517/3/1444835173.geojson
@@ -27,20 +27,17 @@
     "name:fra_x_preferred":[
         "Primev\u00e8res-Savigny"
     ],
-    "name:freng_x_preferred":[
-        "Primeveres-Savigny"
-    ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
     "wof:belongsto":[
-        85683475,
         102191581,
         85633147,
         1159322245,
         404227999,
         404227465,
         101751159,
-        102070009
+        102070009,
+        85683475
     ],
     "wof:breaches":[],
     "wof:country":"FR",
@@ -59,7 +56,7 @@
         }
     ],
     "wof:id":1444835173,
-    "wof:lastmodified":1566338739,
+    "wof:lastmodified":1568226911,
     "wof:name":"Primeveres-Savigny",
     "wof:parent_id":101751159,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes the FR portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1709

This PR removes any bunk iso codes/name properties and empty name lists. Unfortunately, the Git history does not reveal where these empty name strings come from. I also ran this record against wikidata to gain new names, but no new names were found.

This does not require PIP work. Can be merged once approved.