### PR TITLE
Updated department labels in France

### DIFF
--- a/data/856/711/91/85671191.geojson
+++ b/data/856/711/91/85671191.geojson
@@ -23,7 +23,7 @@
         "MQ"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Martinique"
+        "d\u00e9partement de la Martinique"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -731,7 +731,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710079,
+    "wof:lastmodified":1573585441,
     "wof:name":"Martinique",
     "wof:parent_id":85633147,
     "wof:placetype":"region",

--- a/data/856/711/95/85671195.geojson
+++ b/data/856/711/95/85671195.geojson
@@ -23,7 +23,7 @@
         "GF"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Guyane"
+        "d\u00e9partement de la Guyane"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -818,7 +818,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710079,
+    "wof:lastmodified":1573585440,
     "wof:name":"French Guiana",
     "wof:parent_id":85633147,
     "wof:placetype":"region",

--- a/data/856/711/99/85671199.geojson
+++ b/data/856/711/99/85671199.geojson
@@ -23,13 +23,10 @@
         "RE"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement de La R\u00e9union"
+        "d\u00e9partement de la R\u00e9union"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
-    ],
-    "label:fra_x_variant_longname":[
-        "d\u00e9partement des La R\u00e9union"
     ],
     "lbl:latitude":-21.113489,
     "lbl:longitude":55.535699,
@@ -749,7 +746,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1573517584,
+    "wof:lastmodified":1573585427,
     "wof:name":"Reunion",
     "wof:parent_id":85633147,
     "wof:placetype":"region",

--- a/data/856/711/99/85671199.geojson
+++ b/data/856/711/99/85671199.geojson
@@ -23,10 +23,13 @@
         "RE"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des La R\u00e9union"
+        "d\u00e9partement de La R\u00e9union"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
+    ],
+    "label:fra_x_variant_longname":[
+        "d\u00e9partement des La R\u00e9union"
     ],
     "lbl:latitude":-21.113489,
     "lbl:longitude":55.535699,
@@ -746,7 +749,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710079,
+    "wof:lastmodified":1573517584,
     "wof:name":"Reunion",
     "wof:parent_id":85633147,
     "wof:placetype":"region",

--- a/data/856/712/03/85671203.geojson
+++ b/data/856/712/03/85671203.geojson
@@ -23,7 +23,7 @@
         "YT"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Mayotte"
+        "d\u00e9partement de Mayotte"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -719,7 +719,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710076,
+    "wof:lastmodified":1573585441,
     "wof:name":"Mayotte",
     "wof:parent_id":85633147,
     "wof:placetype":"region",

--- a/data/856/712/09/85671209.geojson
+++ b/data/856/712/09/85671209.geojson
@@ -23,7 +23,7 @@
         "GP"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Guadeloupe"
+        "d\u00e9partement de la Guadeloupe"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -751,7 +751,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710076,
+    "wof:lastmodified":1573585440,
     "wof:name":"Guadeloupe",
     "wof:parent_id":85633147,
     "wof:placetype":"region",

--- a/data/856/831/53/85683153.geojson
+++ b/data/856/831/53/85683153.geojson
@@ -20,7 +20,7 @@
         "AI"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Ain"
+        "d\u00e9partement de l'Ain"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -467,7 +467,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585438,
     "wof:name":"Ain",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/831/57/85683157.geojson
+++ b/data/856/831/57/85683157.geojson
@@ -464,7 +464,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585441,
     "wof:name":"Hauts-de-Seine",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/831/63/85683163.geojson
+++ b/data/856/831/63/85683163.geojson
@@ -434,7 +434,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585437,
     "wof:name":"Deux-S\u00e8vres",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/831/67/85683167.geojson
+++ b/data/856/831/67/85683167.geojson
@@ -20,7 +20,7 @@
         "CS"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Corse-du-Sud"
+        "d\u00e9partement de la Corse-du-Sud"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -450,7 +450,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585439,
     "wof:name":"Corse-du-Sud",
     "wof:parent_id":404227453,
     "wof:placetype":"region",

--- a/data/856/831/69/85683169.geojson
+++ b/data/856/831/69/85683169.geojson
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585436,
     "wof:name":"Pyr\u00e9n\u00e9es-Orientales",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/831/73/85683173.geojson
+++ b/data/856/831/73/85683173.geojson
@@ -20,7 +20,7 @@
         "JU"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Jura"
+        "d\u00e9partement du Jura"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -478,7 +478,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585441,
     "wof:name":"Jura",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/831/79/85683179.geojson
+++ b/data/856/831/79/85683179.geojson
@@ -20,7 +20,7 @@
         "CR"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Creuse"
+        "d\u00e9partement de la Creuse"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585431,
     "wof:name":"Creuse",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/831/83/85683183.geojson
+++ b/data/856/831/83/85683183.geojson
@@ -433,7 +433,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710078,
+    "wof:lastmodified":1573585433,
     "wof:name":"Landes",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/831/85/85683185.geojson
+++ b/data/856/831/85/85683185.geojson
@@ -20,7 +20,7 @@
         "VN"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Vienne"
+        "d\u00e9partement de la Vienne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -461,7 +461,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710078,
+    "wof:lastmodified":1573585429,
     "wof:name":"Vienne",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/831/89/85683189.geojson
+++ b/data/856/831/89/85683189.geojson
@@ -20,7 +20,7 @@
         "EL"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Eure-et-Loir"
+        "d\u00e9partement d'Eure-et-Loir"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -434,7 +434,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585440,
     "wof:name":"Eure-et-Loir",
     "wof:parent_id":404227461,
     "wof:placetype":"region",

--- a/data/856/831/93/85683193.geojson
+++ b/data/856/831/93/85683193.geojson
@@ -20,7 +20,7 @@
         "AB"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Aube"
+        "d\u00e9partement de l'Aube"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -449,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710077,
+    "wof:lastmodified":1573585429,
     "wof:name":"Aube",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/832/01/85683201.geojson
+++ b/data/856/832/01/85683201.geojson
@@ -20,7 +20,7 @@
         "VC"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Vaucluse"
+        "d\u00e9partement du Vaucluse"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585428,
     "wof:name":"Vaucluse",
     "wof:parent_id":404227445,
     "wof:placetype":"region",

--- a/data/856/832/03/85683203.geojson
+++ b/data/856/832/03/85683203.geojson
@@ -431,7 +431,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710068,
+    "wof:lastmodified":1573585436,
     "wof:name":"Hautes-Pyr\u00e9n\u00e9es",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/832/09/85683209.geojson
+++ b/data/856/832/09/85683209.geojson
@@ -20,7 +20,7 @@
         "CZ"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Corr\u00e8ze"
+        "d\u00e9partement de la Corr\u00e8ze"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -427,7 +427,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585430,
     "wof:name":"Corr\u00e8ze",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/832/17/85683217.geojson
+++ b/data/856/832/17/85683217.geojson
@@ -20,7 +20,7 @@
         "TG"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Tarn-et-Garonne"
+        "d\u00e9partement de Tarn-et-Garonne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -440,7 +440,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585438,
     "wof:name":"Tarn-et-Garonne",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/832/21/85683221.geojson
+++ b/data/856/832/21/85683221.geojson
@@ -20,7 +20,7 @@
         "BR"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Bas-Rhin"
+        "d\u00e9partement du Bas-Rhin"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -464,7 +464,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585436,
     "wof:name":"Bas-Rhin",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/832/23/85683223.geojson
+++ b/data/856/832/23/85683223.geojson
@@ -536,7 +536,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710070,
+    "wof:lastmodified":1573585438,
     "wof:name":"Vosges",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/832/27/85683227.geojson
+++ b/data/856/832/27/85683227.geojson
@@ -20,7 +20,7 @@
         "HS"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haute-Savoie"
+        "d\u00e9partement de la Haute-Savoie"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -460,7 +460,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710068,
+    "wof:lastmodified":1573585437,
     "wof:name":"Haute-Savoie",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/832/33/85683233.geojson
+++ b/data/856/832/33/85683233.geojson
@@ -20,7 +20,7 @@
         "LA"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Loire-Atlantique"
+        "d\u00e9partement de la Loire-Atlantique"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -449,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710068,
+    "wof:lastmodified":1573585433,
     "wof:name":"Loire-Atlantique",
     "wof:parent_id":404227423,
     "wof:placetype":"region",

--- a/data/856/832/39/85683239.geojson
+++ b/data/856/832/39/85683239.geojson
@@ -20,7 +20,7 @@
         "DB"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Doubs"
+        "d\u00e9partement du Doubs"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -461,7 +461,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585431,
     "wof:name":"Doubs",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/832/43/85683243.geojson
+++ b/data/856/832/43/85683243.geojson
@@ -20,7 +20,7 @@
         "GI"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Gironde"
+        "d\u00e9partement de la Gironde"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -460,7 +460,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585432,
     "wof:name":"Gironde",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/832/47/85683247.geojson
+++ b/data/856/832/47/85683247.geojson
@@ -20,7 +20,7 @@
         "AS"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Aisne"
+        "d\u00e9partement de l'Aisne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -458,7 +458,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710070,
+    "wof:lastmodified":1573585429,
     "wof:name":"Aisne",
     "wof:parent_id":1108826399,
     "wof:placetype":"region",

--- a/data/856/832/51/85683251.geojson
+++ b/data/856/832/51/85683251.geojson
@@ -20,7 +20,7 @@
         "SM"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Seine-Maritime"
+        "d\u00e9partement de la Seine-Maritime"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -464,7 +464,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710068,
+    "wof:lastmodified":1573585428,
     "wof:name":"Seine-Maritime",
     "wof:parent_id":1108826393,
     "wof:placetype":"region",

--- a/data/856/832/55/85683255.geojson
+++ b/data/856/832/55/85683255.geojson
@@ -20,7 +20,7 @@
         "PC"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Pas-de-Calais"
+        "d\u00e9partement du Pas-de-Calais"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -456,7 +456,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585436,
     "wof:name":"Pas-de-Calais",
     "wof:parent_id":1108826399,
     "wof:placetype":"region",

--- a/data/856/832/61/85683261.geojson
+++ b/data/856/832/61/85683261.geojson
@@ -20,7 +20,7 @@
         "HM"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haute-Marne"
+        "d\u00e9partement de la Haute-Marne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -452,7 +452,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710068,
+    "wof:lastmodified":1573585440,
     "wof:name":"Haute-Marne",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/832/65/85683265.geojson
+++ b/data/856/832/65/85683265.geojson
@@ -20,7 +20,7 @@
         "SV"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Savoie"
+        "d\u00e9partement de la Savoie"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -471,7 +471,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585437,
     "wof:name":"Savoie",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/832/71/85683271.geojson
+++ b/data/856/832/71/85683271.geojson
@@ -20,7 +20,7 @@
         "MO"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Moselle"
+        "d\u00e9partement de la Moselle"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -544,7 +544,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710070,
+    "wof:lastmodified":1573585435,
     "wof:name":"Moselle",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/832/75/85683275.geojson
+++ b/data/856/832/75/85683275.geojson
@@ -20,7 +20,7 @@
         "CM"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Charente-Maritime"
+        "d\u00e9partement de la Charente-Maritime"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -455,7 +455,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710069,
+    "wof:lastmodified":1573585439,
     "wof:name":"Charente-Maritime",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/832/79/85683279.geojson
+++ b/data/856/832/79/85683279.geojson
@@ -20,7 +20,7 @@
         "ST"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Sarthe"
+        "d\u00e9partement de la Sarthe"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -444,7 +444,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710070,
+    "wof:lastmodified":1573585437,
     "wof:name":"Sarthe",
     "wof:parent_id":404227423,
     "wof:placetype":"region",

--- a/data/856/832/83/85683283.geojson
+++ b/data/856/832/83/85683283.geojson
@@ -20,7 +20,7 @@
         "EU"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Eure"
+        "d\u00e9partement de L'Eure"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -441,7 +441,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710070,
+    "wof:lastmodified":1573585431,
     "wof:name":"Eure",
     "wof:parent_id":1108826393,
     "wof:placetype":"region",

--- a/data/856/832/89/85683289.geojson
+++ b/data/856/832/89/85683289.geojson
@@ -20,7 +20,7 @@
         "OI"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Oise"
+        "d\u00e9partement de l'Oise"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -449,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710068,
+    "wof:lastmodified":1573585435,
     "wof:name":"Oise",
     "wof:parent_id":1108826399,
     "wof:placetype":"region",

--- a/data/856/832/93/85683293.geojson
+++ b/data/856/832/93/85683293.geojson
@@ -20,7 +20,7 @@
         "AL"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Allier"
+        "d\u00e9partement de l'Allier"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -449,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710068,
+    "wof:lastmodified":1573585429,
     "wof:name":"Allier",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/832/97/85683297.geojson
+++ b/data/856/832/97/85683297.geojson
@@ -20,7 +20,7 @@
         "MS"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Meuse"
+        "d\u00e9partement de la Meuse"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -585,7 +585,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710070,
+    "wof:lastmodified":1573585434,
     "wof:name":"Meuse",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/833/01/85683301.geojson
+++ b/data/856/833/01/85683301.geojson
@@ -20,7 +20,7 @@
         "AV"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Aveyron"
+        "d\u00e9partement de l'Aveyron"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585439,
     "wof:name":"Aveyron",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/833/09/85683309.geojson
+++ b/data/856/833/09/85683309.geojson
@@ -20,7 +20,7 @@
         "AN"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Ardenne"
+        "d\u00e9partement de l'Ardenne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -539,7 +539,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585438,
     "wof:name":"Ardennes",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/833/11/85683311.geojson
+++ b/data/856/833/11/85683311.geojson
@@ -20,7 +20,7 @@
         "IN"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Indre"
+        "d\u00e9partement de l'Indre"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -439,7 +439,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585441,
     "wof:name":"Indre",
     "wof:parent_id":404227461,
     "wof:placetype":"region",

--- a/data/856/833/15/85683315.geojson
+++ b/data/856/833/15/85683315.geojson
@@ -20,7 +20,7 @@
         "VR"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Var"
+        "d\u00e9partement du Var"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -272,7 +272,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585438,
     "wof:name":"Var",
     "wof:parent_id":404227445,
     "wof:placetype":"region",

--- a/data/856/833/23/85683323.geojson
+++ b/data/856/833/23/85683323.geojson
@@ -452,7 +452,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585430,
     "wof:name":"Alpes-Maritimes",
     "wof:parent_id":404227445,
     "wof:placetype":"region",

--- a/data/856/833/27/85683327.geojson
+++ b/data/856/833/27/85683327.geojson
@@ -20,7 +20,7 @@
         "ML"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Maine-et-Loire"
+        "d\u00e9partement de Maine-et-Loire"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -449,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585434,
     "wof:name":"Maine-et-Loire",
     "wof:parent_id":404227423,
     "wof:placetype":"region",

--- a/data/856/833/31/85683331.geojson
+++ b/data/856/833/31/85683331.geojson
@@ -20,7 +20,7 @@
         "DD"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Dordogne"
+        "d\u00e9partement de la Dordogne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -457,7 +457,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585431,
     "wof:name":"Dordogne",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/833/35/85683335.geojson
+++ b/data/856/833/35/85683335.geojson
@@ -20,7 +20,7 @@
         "AG"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Ari\u00e8ge"
+        "d\u00e9partement de l'Ari\u00e8ge"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -424,7 +424,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585438,
     "wof:name":"Ari\u00e8ge",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/833/41/85683341.geojson
+++ b/data/856/833/41/85683341.geojson
@@ -20,7 +20,7 @@
         "LG"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Lot-et-Garonne"
+        "d\u00e9partement de Lot-et-Garonne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -446,7 +446,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585434,
     "wof:name":"Lot-et-Garonne",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/833/43/85683343.geojson
+++ b/data/856/833/43/85683343.geojson
@@ -20,7 +20,7 @@
         "MM"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Meurthe-et-Moselle"
+        "d\u00e9partement de la Meurthe-et-Moselle"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -382,7 +382,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585441,
     "wof:name":"Meurthe-et-Moselle",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/833/49/85683349.geojson
+++ b/data/856/833/49/85683349.geojson
@@ -20,7 +20,7 @@
         "LC"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Loir-et-Cher"
+        "d\u00e9partement de Loir-et-Cher"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -434,7 +434,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585433,
     "wof:name":"Loir-et-Cher",
     "wof:parent_id":404227461,
     "wof:placetype":"region",

--- a/data/856/833/53/85683353.geojson
+++ b/data/856/833/53/85683353.geojson
@@ -20,7 +20,7 @@
         "TB"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Territoire de Belfort"
+        "d\u00e9partement du Territoire de Belfort"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -457,7 +457,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585439,
     "wof:name":"Territoire de Belfort",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/833/59/85683359.geojson
+++ b/data/856/833/59/85683359.geojson
@@ -20,7 +20,7 @@
         "NI"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Ni\u00e8vre"
+        "d\u00e9partement de la Ni\u00e8vre"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -428,7 +428,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710070,
+    "wof:lastmodified":1573585435,
     "wof:name":"Ni\u00e8vre",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/833/63/85683363.geojson
+++ b/data/856/833/63/85683363.geojson
@@ -20,7 +20,7 @@
         "SO"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Somme"
+        "d\u00e9partement de la Somme"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -448,7 +448,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585437,
     "wof:name":"Somme",
     "wof:parent_id":1108826399,
     "wof:placetype":"region",

--- a/data/856/833/67/85683367.geojson
+++ b/data/856/833/67/85683367.geojson
@@ -447,7 +447,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585429,
     "wof:name":"Yvelines",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/833/71/85683371.geojson
+++ b/data/856/833/71/85683371.geojson
@@ -20,7 +20,7 @@
         "ES"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Essonne"
+        "d\u00e9partement de la Essonne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -441,7 +441,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585440,
     "wof:name":"Essonne",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/833/77/85683377.geojson
+++ b/data/856/833/77/85683377.geojson
@@ -20,7 +20,7 @@
         "LR"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Loire"
+        "d\u00e9partement de la Loire"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -444,7 +444,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585433,
     "wof:name":"Loire",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/833/81/85683381.geojson
+++ b/data/856/833/81/85683381.geojson
@@ -20,7 +20,7 @@
         "HR"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haut-Rhin"
+        "d\u00e9partement du Haut-Rhin"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -391,7 +391,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585436,
     "wof:name":"Haut-Rhin",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/833/85/85683385.geojson
+++ b/data/856/833/85/85683385.geojson
@@ -20,7 +20,7 @@
         "SE"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Seine-et-Marne"
+        "d\u00e9partement de Seine-et-Marne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -368,7 +368,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585428,
     "wof:name":"Seine-et-Marne",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/833/89/85683389.geojson
+++ b/data/856/833/89/85683389.geojson
@@ -20,7 +20,7 @@
         "LO"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Lot"
+        "d\u00e9partement du Lot"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -446,7 +446,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710071,
+    "wof:lastmodified":1573585434,
     "wof:name":"Lot",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/833/97/85683397.geojson
+++ b/data/856/833/97/85683397.geojson
@@ -20,7 +20,7 @@
         "HG"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haute-Garonne"
+        "d\u00e9partement de la Haute-Garonne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -456,7 +456,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710072,
+    "wof:lastmodified":1573585432,
     "wof:name":"Haute-Garonne",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/834/01/85683401.geojson
+++ b/data/856/834/01/85683401.geojson
@@ -428,7 +428,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585441,
     "wof:name":"Mayenne",
     "wof:parent_id":404227423,
     "wof:placetype":"region",

--- a/data/856/834/05/85683405.geojson
+++ b/data/856/834/05/85683405.geojson
@@ -20,7 +20,7 @@
         "MR"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Marne"
+        "d\u00e9partement de la Marne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -444,7 +444,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585435,
     "wof:name":"Marne",
     "wof:parent_id":1108826391,
     "wof:placetype":"region",

--- a/data/856/834/09/85683409.geojson
+++ b/data/856/834/09/85683409.geojson
@@ -20,7 +20,7 @@
         "VD"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Vend\u00e9e"
+        "d\u00e9partement de la Vend\u00e9e"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -440,7 +440,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585428,
     "wof:name":"Vend\u00e9e",
     "wof:parent_id":404227423,
     "wof:placetype":"region",

--- a/data/856/834/13/85683413.geojson
+++ b/data/856/834/13/85683413.geojson
@@ -20,7 +20,7 @@
         "HL"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haute-Loire"
+        "d\u00e9partement de la Haute-Loire"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -452,7 +452,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585433,
     "wof:name":"Haute-Loire",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/834/19/85683419.geojson
+++ b/data/856/834/19/85683419.geojson
@@ -20,7 +20,7 @@
         "HE"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des H\u00e9rault"
+        "d\u00e9partement de L'H\u00e9rault"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -461,7 +461,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585432,
     "wof:name":"H\u00e9rault",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/834/21/85683421.geojson
+++ b/data/856/834/21/85683421.geojson
@@ -20,7 +20,7 @@
         "AH"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Ard\u00e8che"
+        "d\u00e9partement de l'Ard\u00e8che"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -434,7 +434,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585438,
     "wof:name":"Ard\u00e8che",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/834/27/85683427.geojson
+++ b/data/856/834/27/85683427.geojson
@@ -20,7 +20,7 @@
         "IS"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Is\u00e8re"
+        "d\u00e9partement de l'Is\u00e8re"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585433,
     "wof:name":"Is\u00e8re",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/834/31/85683431.geojson
+++ b/data/856/834/31/85683431.geojson
@@ -25,9 +25,6 @@
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
     ],
-    "label:fra_x_variant_longname":[
-        "d\u00e9partement des Gard"
-    ],
     "lbl:latitude":44.013111,
     "lbl:longitude":4.191147,
     "mps:latitude":44.013111,
@@ -452,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1573517581,
+    "wof:lastmodified":1573585432,
     "wof:name":"Gard",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/834/31/85683431.geojson
+++ b/data/856/834/31/85683431.geojson
@@ -20,10 +20,13 @@
         "GA"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Gard"
+        "d\u00e9partement du Gard"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
+    ],
+    "label:fra_x_variant_longname":[
+        "d\u00e9partement des Gard"
     ],
     "lbl:latitude":44.013111,
     "lbl:longitude":4.191147,
@@ -449,7 +452,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573517581,
     "wof:name":"Gard",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/834/37/85683437.geojson
+++ b/data/856/834/37/85683437.geojson
@@ -20,7 +20,7 @@
         "CT"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Charente"
+        "d\u00e9partement de la Charente"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585430,
     "wof:name":"Charente",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/834/41/85683441.geojson
+++ b/data/856/834/41/85683441.geojson
@@ -407,7 +407,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585430,
     "wof:name":"Bouches-du-Rh\u00f4ne",
     "wof:parent_id":404227445,
     "wof:placetype":"region",

--- a/data/856/834/45/85683445.geojson
+++ b/data/856/834/45/85683445.geojson
@@ -20,7 +20,7 @@
         "NO"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Nord"
+        "d\u00e9partement du Nord"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -267,7 +267,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585435,
     "wof:name":"Nord",
     "wof:parent_id":1108826399,
     "wof:placetype":"region",

--- a/data/856/834/51/85683451.geojson
+++ b/data/856/834/51/85683451.geojson
@@ -20,7 +20,7 @@
         "VO"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Val-d'Oise"
+        "d\u00e9partement deu Val-d'Oise"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -455,7 +455,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585428,
     "wof:name":"Val-d'Oise",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/834/53/85683453.geojson
+++ b/data/856/834/53/85683453.geojson
@@ -20,7 +20,7 @@
         "LZ"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Loz\u00e8re"
+        "d\u00e9partement de la Loz\u00e8re"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -425,7 +425,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585434,
     "wof:name":"Loz\u00e8re",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/834/59/85683459.geojson
+++ b/data/856/834/59/85683459.geojson
@@ -20,7 +20,7 @@
         "VM"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Val-de-Marne"
+        "d\u00e9partement du Val-de-Marne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -446,7 +446,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585428,
     "wof:name":"Val-de-Marne",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/834/61/85683461.geojson
+++ b/data/856/834/61/85683461.geojson
@@ -20,7 +20,7 @@
         "IV"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Ille-et-Vilaine"
+        "d\u00e9partement d'Ille-et-Vilaine"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -437,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585432,
     "wof:name":"Ille-et-Vilaine",
     "wof:parent_id":404227447,
     "wof:placetype":"region",

--- a/data/856/834/67/85683467.geojson
+++ b/data/856/834/67/85683467.geojson
@@ -20,7 +20,7 @@
         "GE"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Gers"
+        "d\u00e9partement du Gers"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -449,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585432,
     "wof:name":"Gers",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/834/71/85683471.geojson
+++ b/data/856/834/71/85683471.geojson
@@ -20,7 +20,7 @@
         "PD"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Puy-de-D\u00f4me"
+        "d\u00e9partement du Puy-de-D\u00f4me"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -431,7 +431,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585436,
     "wof:name":"Puy-de-D\u00f4me",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/834/75/85683475.geojson
+++ b/data/856/834/75/85683475.geojson
@@ -20,7 +20,7 @@
         "SS"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Seine-Saint-Denis"
+        "d\u00e9partement de la Seine-Saint-Denis"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -460,7 +460,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585428,
     "wof:name":"Seine-Saint-Denis",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/834/79/85683479.geojson
+++ b/data/856/834/79/85683479.geojson
@@ -20,7 +20,7 @@
         "LT"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Loiret"
+        "d\u00e9partement du Loiret"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -453,7 +453,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585434,
     "wof:name":"Loiret",
     "wof:parent_id":404227461,
     "wof:placetype":"region",

--- a/data/856/834/85/85683485.geojson
+++ b/data/856/834/85/85683485.geojson
@@ -20,7 +20,7 @@
         "AD"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Aude"
+        "d\u00e9partement de l'Aude"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -437,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585430,
     "wof:name":"Aude",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",

--- a/data/856/834/89/85683489.geojson
+++ b/data/856/834/89/85683489.geojson
@@ -20,7 +20,7 @@
         "MH"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Manche"
+        "d\u00e9partement de la Manche"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -452,7 +452,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710074,
+    "wof:lastmodified":1573585434,
     "wof:name":"Manche",
     "wof:parent_id":1108826393,
     "wof:placetype":"region",

--- a/data/856/834/93/85683493.geojson
+++ b/data/856/834/93/85683493.geojson
@@ -20,7 +20,7 @@
         "HC"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haute-Corse"
+        "d\u00e9partement de la Haute-Corse"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -453,7 +453,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710073,
+    "wof:lastmodified":1573585440,
     "wof:name":"Haute-Corse",
     "wof:parent_id":404227453,
     "wof:placetype":"region",

--- a/data/856/834/97/85683497.geojson
+++ b/data/856/834/97/85683497.geojson
@@ -20,7 +20,7 @@
         "VP"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Paris"
+        "d\u00e9partement de Paris"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -1028,7 +1028,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710075,
+    "wof:lastmodified":1573585427,
     "wof:name":"Paris",
     "wof:parent_id":404227465,
     "wof:placetype":"region",

--- a/data/856/835/03/85683503.geojson
+++ b/data/856/835/03/85683503.geojson
@@ -20,7 +20,7 @@
         "YO"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Yonne"
+        "d\u00e9partement de l'Yonne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -446,7 +446,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710065,
+    "wof:lastmodified":1573585429,
     "wof:name":"Yonne",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/835/07/85683507.geojson
+++ b/data/856/835/07/85683507.geojson
@@ -25,9 +25,6 @@
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
     ],
-    "label:fra_x_variant_longname":[
-        "d\u00e9partement des Morbihan"
-    ],
     "lbl:latitude":47.87757,
     "lbl:longitude":-2.874304,
     "mps:latitude":47.87757,
@@ -461,7 +458,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1573519336,
+    "wof:lastmodified":1573585435,
     "wof:name":"Morbihan",
     "wof:parent_id":404227447,
     "wof:placetype":"region",

--- a/data/856/835/07/85683507.geojson
+++ b/data/856/835/07/85683507.geojson
@@ -20,10 +20,13 @@
         "MB"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Morbihan"
+        "d\u00e9partement du Morbihan"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
+    ],
+    "label:fra_x_variant_longname":[
+        "d\u00e9partement des Morbihan"
     ],
     "lbl:latitude":47.87757,
     "lbl:longitude":-2.874304,
@@ -458,7 +461,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710066,
+    "wof:lastmodified":1573519336,
     "wof:name":"Morbihan",
     "wof:parent_id":404227447,
     "wof:placetype":"region",

--- a/data/856/835/09/85683509.geojson
+++ b/data/856/835/09/85683509.geojson
@@ -446,7 +446,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710066,
+    "wof:lastmodified":1573585430,
     "wof:name":"Alpes-de-Haute-Provence",
     "wof:parent_id":404227445,
     "wof:placetype":"region",

--- a/data/856/835/15/85683515.geojson
+++ b/data/856/835/15/85683515.geojson
@@ -414,7 +414,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710067,
+    "wof:lastmodified":1573585431,
     "wof:name":"C\u00f4tes-d'Armor",
     "wof:parent_id":404227447,
     "wof:placetype":"region",

--- a/data/856/835/17/85683517.geojson
+++ b/data/856/835/17/85683517.geojson
@@ -20,7 +20,7 @@
         "CL"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Cantal"
+        "d\u00e9partement du Cantal"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -437,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710066,
+    "wof:lastmodified":1573585439,
     "wof:name":"Cantal",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/835/23/85683523.geojson
+++ b/data/856/835/23/85683523.geojson
@@ -20,7 +20,7 @@
         "DM"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Dr\u00f4me"
+        "d\u00e9partement de la Dr\u00f4me"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -434,7 +434,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710067,
+    "wof:lastmodified":1573585439,
     "wof:name":"Dr\u00f4me",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/835/27/85683527.geojson
+++ b/data/856/835/27/85683527.geojson
@@ -20,7 +20,7 @@
         "OR"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Orne"
+        "d\u00e9partement de l'Orne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710065,
+    "wof:lastmodified":1573585435,
     "wof:name":"Orne",
     "wof:parent_id":1108826393,
     "wof:placetype":"region",

--- a/data/856/835/31/85683531.geojson
+++ b/data/856/835/31/85683531.geojson
@@ -20,7 +20,7 @@
         "HV"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haute-Vienne"
+        "d\u00e9partement de la Haute-Vienne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -461,7 +461,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710066,
+    "wof:lastmodified":1573585440,
     "wof:name":"Haute-Vienne",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/835/39/85683539.geojson
+++ b/data/856/835/39/85683539.geojson
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1568054278,
+    "wof:lastmodified":1573585436,
     "wof:name":"Pyr\u00e9n\u00e9es-Atlantiques",
     "wof:parent_id":1108826385,
     "wof:placetype":"region",

--- a/data/856/835/43/85683543.geojson
+++ b/data/856/835/43/85683543.geojson
@@ -20,7 +20,7 @@
         "SL"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Sa\u00f4ne-et-Loire"
+        "d\u00e9partement de Sa\u00f4ne-et-Loire"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -431,7 +431,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710066,
+    "wof:lastmodified":1573585437,
     "wof:name":"Sa\u00f4ne-et-Loire",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/835/49/85683549.geojson
+++ b/data/856/835/49/85683549.geojson
@@ -20,7 +20,7 @@
         "CH"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Cher"
+        "d\u00e9partement du Cher"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -426,7 +426,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710067,
+    "wof:lastmodified":1573585430,
     "wof:name":"Cher",
     "wof:parent_id":404227461,
     "wof:placetype":"region",

--- a/data/856/835/53/85683553.geojson
+++ b/data/856/835/53/85683553.geojson
@@ -20,7 +20,7 @@
         "FI"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Finistere"
+        "d\u00e9partement du Finistere"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -443,7 +443,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710067,
+    "wof:lastmodified":1573585431,
     "wof:name":"Finist\u00e8re",
     "wof:parent_id":404227447,
     "wof:placetype":"region",

--- a/data/856/835/59/85683559.geojson
+++ b/data/856/835/59/85683559.geojson
@@ -20,7 +20,7 @@
         "HN"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Haute-Sa\u00f4ne"
+        "d\u00e9partement de la Haute-Sa\u00f4ne"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -437,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710065,
+    "wof:lastmodified":1573585440,
     "wof:name":"Haute-Sa\u00f4ne",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/835/63/85683563.geojson
+++ b/data/856/835/63/85683563.geojson
@@ -20,7 +20,7 @@
         "CO"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des C\u00f4te-d'Or"
+        "d\u00e9partement de la C\u00f4te-d'Or"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -625,7 +625,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710067,
+    "wof:lastmodified":1573585430,
     "wof:name":"C\u00f4te-d'Or",
     "wof:parent_id":1108826395,
     "wof:placetype":"region",

--- a/data/856/835/69/85683569.geojson
+++ b/data/856/835/69/85683569.geojson
@@ -453,7 +453,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710065,
+    "wof:lastmodified":1573585437,
     "wof:name":"Rh\u00f4ne",
     "wof:parent_id":1108826389,
     "wof:placetype":"region",

--- a/data/856/835/75/85683575.geojson
+++ b/data/856/835/75/85683575.geojson
@@ -20,7 +20,7 @@
         "IL"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Indre-et-Loire"
+        "d\u00e9partement d'Indre-et-Loire"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -449,7 +449,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710066,
+    "wof:lastmodified":1573585432,
     "wof:name":"Indre-et-Loire",
     "wof:parent_id":404227461,
     "wof:placetype":"region",

--- a/data/856/835/79/85683579.geojson
+++ b/data/856/835/79/85683579.geojson
@@ -20,7 +20,7 @@
         "CV"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Calvados"
+        "d\u00e9partement du Calvados"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -454,7 +454,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710067,
+    "wof:lastmodified":1573585439,
     "wof:name":"Calvados",
     "wof:parent_id":1108826393,
     "wof:placetype":"region",

--- a/data/856/835/97/85683597.geojson
+++ b/data/856/835/97/85683597.geojson
@@ -446,7 +446,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710067,
+    "wof:lastmodified":1573585440,
     "wof:name":"Hautes-Alpes",
     "wof:parent_id":404227445,
     "wof:placetype":"region",

--- a/data/856/836/03/85683603.geojson
+++ b/data/856/836/03/85683603.geojson
@@ -20,7 +20,7 @@
         "TA"
     ],
     "label:fra_x_preferred_longname":[
-        "d\u00e9partement des Tarn"
+        "d\u00e9partement du Tarn"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
@@ -440,7 +440,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1565710078,
+    "wof:lastmodified":1573585437,
     "wof:name":"Tarn",
     "wof:parent_id":1108826387,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1734.

- Updates `label:`properties in two French departments (regions)
- Stores the existing longname label as a variant, updates the preferred longname

No PIP work or geometry edits, can merge once approved.