### PR TITLE
Fix names, remove bad wiki concordance in locality record

### DIFF
--- a/data/101/883/943/101883943.geojson
+++ b/data/101/883/943/101883943.geojson
@@ -74,10 +74,10 @@
         "Barbas"
     ],
     "name:fra_x_preferred":[
-        "Marbas"
+        "Barbas"
     ],
     "name:fra_x_variant":[
-        "Barbas"
+        "Marbas"
     ],
     "name:frc_x_preferred":[
         "Barbas"
@@ -343,8 +343,7 @@
         "gn:id":3035050,
         "gp:id":578086,
         "qs:id":322821,
-        "wd:id":"Q858286",
-        "wk:page":"Montaldo Roero"
+        "wd:id":"Q858286"
     },
     "wof:coterminous":[
         404422575
@@ -368,7 +367,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1563290463,
+    "wof:lastmodified":1576540203,
     "wof:name":"Barbas",
     "wof:parent_id":404422575,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1747

- Swaps variant and preferred French name translation values
- Removes bad wikipedia concordance (other concordances are okay)

No PIP work needed, just property updates here.