### PR TITLE
Bad translation for Pompey, France locality

### DIFF
--- a/data/101/757/391/101757391.geojson
+++ b/data/101/757/391/101757391.geojson
@@ -141,7 +141,7 @@
         "Pompey"
     ],
     "name:fra_x_preferred":[
-        "Pomp\u00e9e"
+        "Pompey"
     ],
     "name:fra_x_variant":[
         "Pompey"


### PR DESCRIPTION
There was an error for the name:fra_x_preferred attribute. The translation was wrong, it's not "Pompey" the greek character, it's "Pompey" the locality near Nancy, France.