### PR TITLE
Update properties of megacities

### DIFF
--- a/data/101/748/979/101748979.geojson
+++ b/data/101/748/979/101748979.geojson
@@ -16,7 +16,7 @@
     "mps:latitude":44.842411,
     "mps:longitude":-0.570437,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":5.0,
     "name:ace_x_preferred":[
         "Bordeaux"
@@ -660,6 +660,7 @@
         "gn:id":3031582,
         "gp:id":580778,
         "loc:id":"n79091189",
+        "ne:id":1159150035,
         "nyt:id":"N64806170729203909561",
         "qs:id":1062871,
         "qs_pg:id":435782,
@@ -693,7 +694,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1608036347,
+    "wof:lastmodified":1608688172,
     "wof:megacity":1,
     "wof:name":"Bordeaux",
     "wof:parent_id":1159322077,

--- a/data/101/749/199/101749199.geojson
+++ b/data/101/749/199/101749199.geojson
@@ -722,6 +722,7 @@
         "fct:id":"0a65c1cc-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2995469,
         "gp:id":610264,
+        "ne:id":1159150037,
         "nyt:id":"N65372056499171597971",
         "qs:id":783339,
         "qs_pg:id":783339,
@@ -748,7 +749,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1607462677,
+    "wof:lastmodified":1608688172,
     "wof:megacity":1,
     "wof:name":"Marseille",
     "wof:parent_id":102072499,

--- a/data/101/749/273/101749273.geojson
+++ b/data/101/749/273/101749273.geojson
@@ -571,6 +571,7 @@
         "fct:id":"0a4f23a4-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2990440,
         "gp:id":614274,
+        "ne:id":1159147221,
         "nyt:id":"N38413199323774296051",
         "qs:id":783711,
         "qs_pg:id":783711,
@@ -603,7 +604,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1608036315,
+    "wof:lastmodified":1608688165,
     "wof:megacity":1,
     "wof:name":"Nice",
     "wof:parent_id":1159322131,

--- a/data/101/749/431/101749431.geojson
+++ b/data/101/749/431/101749431.geojson
@@ -750,6 +750,7 @@
         "gn:id":2996934,
         "gp:id":609128,
         "loc:id":"n81086849",
+        "ne:id":1159150845,
         "nyt:id":"N38390240477017513971",
         "qs:id":783249,
         "qs_pg:id":1229121,
@@ -783,7 +784,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1607462678,
+    "wof:lastmodified":1608688177,
     "wof:megacity":1,
     "wof:name":"Lyon",
     "wof:parent_id":102072419,

--- a/data/101/750/277/101750277.geojson
+++ b/data/101/750/277/101750277.geojson
@@ -623,6 +623,7 @@
         "fct:id":"0a440a00-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2998324,
         "gp:id":608105,
+        "ne:id":1159147227,
         "qs:id":274247,
         "qs_pg:id":274247,
         "wd:id":"Q648",
@@ -655,7 +656,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1608036453,
+    "wof:lastmodified":1608688165,
     "wof:megacity":1,
     "wof:name":"Lille",
     "wof:parent_id":1159322397,

--- a/data/101/750/691/101750691.geojson
+++ b/data/101/750/691/101750691.geojson
@@ -672,6 +672,7 @@
         "gn:id":2972315,
         "gp:id":628886,
         "loc:id":"n79091182",
+        "ne:id":1159147223,
         "nyt:id":"N46549720520264427371",
         "qs:id":785043,
         "qs_pg:id":785043,
@@ -705,7 +706,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1608036457,
+    "wof:lastmodified":1608688165,
     "wof:megacity":1,
     "wof:name":"Toulouse",
     "wof:parent_id":1159321987,

--- a/data/101/751/119/101751119.geojson
+++ b/data/101/751/119/101751119.geojson
@@ -17,7 +17,7 @@
     "mps:longitude":2.342865,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":2.0,
+    "mz:min_zoom":1.7,
     "name:ace_x_preferred":[
         "Paris"
     ],
@@ -1056,6 +1056,7 @@
         "gn:id":2988507,
         "gp:id":615702,
         "loc:id":"n79058874",
+        "ne:id":1159151613,
         "nyt:id":"N38451885616396959731",
         "qs:id":783857,
         "qs_pg:id":783857,
@@ -1088,7 +1089,8 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1608036433,
+    "wof:lastmodified":1608688193,
+    "wof:megacity":1,
     "wof:name":"Paris",
     "wof:parent_id":1159322569,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary