### PR TITLE
Updated French label

### DIFF
--- a/data/856/834/51/85683451.geojson
+++ b/data/856/834/51/85683451.geojson
@@ -20,13 +20,15 @@
         "VO"
     ],
     "label:fra_x_preferred_longname":[
-        "D\u00e9partement de Val-d'Oise"
+        "D\u00e9partement du Val-d'Oise"
     ],
     "label:fra_x_preferred_placetype":[
         "d\u00e9partement"
     ],
     "label:fra_x_variant_longname":[
-        "d\u00e9partement de Val-d'Oise"
+        "d\u00e9partement de Val-d'Oise",
+        "D\u00e9partement de Val-d'Oise",
+        "d\u00e9partement du Val-d'Oise"
     ],
     "lbl:latitude":49.102394,
     "lbl:longitude":2.056498,
@@ -459,7 +461,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1588976239,
+    "wof:lastmodified":1617035666,
     "wof:name":"Val-d'Oise",
     "wof:parent_id":404227465,
     "wof:placetype":"region",


### PR DESCRIPTION
This PR corrects the French `label` properties to correct a small issue with the current longname. Rather than "Departement de Val-d'Oise", the correct spelling is "Departement du Val-d'Oise". The variant property has been updated to include the existing longname value.

No PIP work, can merge as-is.