### PR TITLE
(#2021) Fix Cherbourg-en-Cotentin labels

### DIFF
--- a/data/101/840/307/101840307.geojson
+++ b/data/101/840/307/101840307.geojson
@@ -18,274 +18,274 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "name:afr_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:arg_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ast_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:bam_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:bar_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:bre_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:bug_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:cat_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ceb_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ces_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:cos_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:cym_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:dan_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:deu_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:eng_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:epo_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:est_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:eus_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:fao_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:fin_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:fra_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:frc_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:frp_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:fur_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:gla_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:gle_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:glg_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:gsw_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:hrv_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:hun_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ido_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ile_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ina_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ind_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:isl_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ita_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:jam_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:jpn_x_preferred":[
         "\u30c8\u30a5\u30eb\u30e9\u30f4\u30a3\u30eb"
     ],
     "name:kab_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:kal_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:kaz_x_preferred":[
         "\u0422\u0443\u0440\u043b\u0430\u0432\u0438\u043b\u044c"
     ],
     "name:kon_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:lat_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:lav_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:lij_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:lim_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:lit_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ltz_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:min_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:mlg_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:msa_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nan_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nap_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nds_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nld_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nno_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nob_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nrm_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:oci_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:pap_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:pcd_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:pms_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:pol_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:por_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:prg_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:rgn_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:roh_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ron_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:rus_x_preferred":[
         "\u0422\u0443\u0440\u043b\u0430\u0432\u0438\u043b\u044c"
     ],
     "name:scn_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:sco_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:slk_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:spa_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:srd_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:swa_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:swe_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:tur_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0443\u0440\u043b\u0430\u0432\u0456\u043b\u044c"
     ],
     "name:uzb_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:vec_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:vie_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:vls_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:vmf_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:vol_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:war_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:wln_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:wol_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:zho_min_nan_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:zho_x_preferred":[
         "\u56fe\u5c14\u62c9\u7ef4\u5c14"
     ],
     "name:zul_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "qs:a0":"France",
     "qs:a1":"*Manche",
@@ -295,8 +295,8 @@
     "qs:la":"Urville-Nacqueville",
     "qs:la_lc":"*FR2550204611",
     "qs:level":"locality",
-    "qs:loc":"Tourlaville",
-    "qs:loc_alt":"Tourlaville",
+    "qs:loc":"Cherbourg-en-Cotentin",
+    "qs:loc_alt":"Cherbourg-en-Cotentin",
     "qs:pop":0,
     "qs:source":"ACustom EuroGlobalMap + UMZ Urban Polygons + Geonames + GeoPlanet",
     "qs:type":"rural point-multi-in-poly-resolved",
@@ -325,7 +325,7 @@
         "qs:id":246950,
         "qs_pg:id":246950,
         "wd:id":"Q627225",
-        "wk:page":"Tourlaville"
+        "wk:page":"Cherbourg-en-Cotentin"
     },
     "wof:coterminous":[
         404416031,
@@ -355,7 +355,7 @@
         "fre"
     ],
     "wof:lastmodified":1608036740,
-    "wof:name":"Tourlaville",
+    "wof:name":"Cherbourg-en-Cotentin",
     "wof:parent_id":404416031,
     "wof:placetype":"locality",
     "wof:population":18273,

--- a/data/404/416/031/404416031.geojson
+++ b/data/404/416/031/404416031.geojson
@@ -26,88 +26,88 @@
     "mz:hierarchy_label":0,
     "mz:is_current":1,
     "name:bar_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:bre_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:bug_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:cat_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ceb_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:deu_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:eus_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:fra_x_preferred":[
         "Cherbourg-en-Cotentin"
     ],
     "name:fra_x_variant":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:hun_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ita_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:kaz_x_preferred":[
         "\u0422\u0443\u0440\u043b\u0430\u0432\u0438\u043b\u044c"
     ],
     "name:lat_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:msa_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:nld_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:oci_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:pms_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:pol_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:por_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ron_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:slk_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:spa_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:swe_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0443\u0440\u043b\u0430\u0432\u0456\u043b\u044c"
     ],
     "name:uzb_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:vie_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:vol_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:war_x_preferred":[
-        "Tourlaville"
+        "Cherbourg-en-Cotentin"
     ],
     "name:zho_x_preferred":[
         "\u56fe\u62c9\u7ef4\u5c14"
@@ -172,7 +172,7 @@
     ],
     "wof:id":404416031,
     "wof:lastmodified":1608038373,
-    "wof:name":"Tourlaville",
+    "wof:name":"Cherbourg-en-Cotentin",
     "wof:parent_id":102071603,
     "wof:placetype":"localadmin",
     "wof:placetype_local":"Sous-pr\u00e9fecture",


### PR DESCRIPTION
This patch renames "Tourlaville" localadmin and locality to "Cherbourg-en-Cotentin" which is the current name of the place.

Linked issue: https://github.com/whosonfirst-data/whosonfirst-data/issues/2021