### PR TITLE
Repair the Benerville-sur-Mer locality hierarchy

### DIFF
--- a/data/112/578/204/5/1125782045.geojson
+++ b/data/112/578/204/5/1125782045.geojson
@@ -343,7 +343,16 @@
     "woe:name_adm0":"France",
     "woe:name_adm1":"Basse-Normandie",
     "woe:placetype":"Town",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85683579,
+        102191581,
+        404228031,
+        404422563,
+        85633147,
+        1108826393,
+        136253037,
+        102070567
+    ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":3033502,
@@ -362,16 +371,21 @@
     "wof:geomhash":"82fc14dfe3e075ef846d1b95971f3593",
     "wof:hierarchy":[
         {
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633147,
+            "county_id":102070567,
+            "empire_id":136253037,
+            "localadmin_id":404422563,
             "locality_id":1125782045,
-            "region_id":-1
+            "macrocounty_id":404228031,
+            "macroregion_id":1108826393,
+            "region_id":85683579
         }
     ],
     "wof:id":1125782045,
-    "wof:lastmodified":1690904096,
+    "wof:lastmodified":1784418387,
     "wof:name":"Benerville-sur-Mer",
-    "wof:parent_id":-1,
+    "wof:parent_id":404422563,
     "wof:placetype":"locality",
     "wof:population":536,
     "wof:population_rank":2,


### PR DESCRIPTION
This fixes the hierarchy reported in whosonfirst-data/whosonfirst-data#2266.

The Benerville-sur-Mer locality is coterminous with localadmin 404422563, but currently has parent -1 and an empty/unknown hierarchy. This change:

- uses the coterminous localadmin as its parent;
- restores the existing France / Normandy / Calvados ancestry;
- leaves the geometry unchanged.

I checked the parent chain against the localadmin record and the neighboring Deauville and Trouville-sur-Mer locality pattern.